### PR TITLE
Feat/testing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,232 @@
+# GitHub Actions Workflows
+
+This directory contains CI/CD workflows for the Fire Recovery Frontend.
+
+## Workflows
+
+### 🧪 test.yml - Test Suite
+
+**Triggers:**
+- Push to `main` branch
+- Push to `dev` branch
+- Pull requests to `main` branch
+- Pull requests to `dev` branch
+
+**Jobs:**
+
+1. **test** - Runs unit tests and generates coverage
+   - Sets up Node.js 20.x and pnpm
+   - Installs dependencies
+   - Runs TypeScript type checking (`pnpm type-check`)
+   - Runs unit tests (`pnpm test`)
+   - Generates coverage report (`pnpm test:coverage`)
+   - Uploads coverage to Codecov (requires `CODECOV_TOKEN` secret)
+   - Archives coverage artifacts for 7 days
+   - Comments PR with coverage summary
+
+2. **lint** - Code quality checks
+   - Runs linter if `pnpm lint` script exists
+   - Skips gracefully if no linter configured
+
+3. **build** - Build verification
+   - Verifies project builds successfully (`pnpm build`)
+   - Archives build artifacts for 7 days
+
+4. **test-summary** - Summary report
+   - Aggregates results from all jobs
+   - Posts summary to GitHub Actions summary
+   - Fails if any critical job failed
+
+**Status Badges:**
+
+Add to your README.md:
+```markdown
+[![Tests](https://github.com/SchmidtDSE/fire-recovery-frontend/actions/workflows/test.yml/badge.svg)](https://github.com/SchmidtDSE/fire-recovery-frontend/actions/workflows/test.yml)
+```
+
+---
+
+### 🚀 deploy.yml - Deployment
+
+**Triggers:**
+- Push to `main` branch (deploys to production)
+- Push to `dev` branch (deploys to development)
+- Manual workflow dispatch
+
+**Jobs:**
+
+1. **deploy-frontend** - Deploy static website to Minio
+   - Deploys to production bucket (`fire-recovery-web/prod/`) on `main` branch
+   - Deploys to development bucket (`fire-recovery-web/dev/`) on `dev` branch
+   - Sets no-cache headers on all files
+
+**Required Secrets:**
+- `MINIO_ENDPOINT` - Minio server endpoint
+- `MINIO_ACCESS_KEY` - Minio access key
+- `MINIO_SECRET_KEY` - Minio secret key
+
+---
+
+## Configuration
+
+### Required Secrets
+
+Go to **Settings → Secrets and variables → Actions** and add:
+
+| Secret | Description | Required For |
+|--------|-------------|--------------|
+| `CODECOV_TOKEN` | Codecov upload token | test.yml (optional) |
+| `MINIO_ENDPOINT` | Minio storage endpoint | deploy.yml |
+| `MINIO_ACCESS_KEY` | Minio access key | deploy.yml |
+| `MINIO_SECRET_KEY` | Minio secret key | deploy.yml |
+
+### Coverage Thresholds
+
+Configured in `vitest.config.ts`:
+- Statements: ≥60%
+- Branches: ≥50%
+- Functions: ≥60%
+- Lines: ≥60%
+
+If coverage falls below these thresholds, tests will fail.
+
+---
+
+## Local Testing
+
+To run the same checks locally before pushing:
+
+```bash
+# Run all checks
+pnpm type-check && pnpm test && pnpm build
+
+# Run with coverage
+pnpm test:coverage
+
+# Watch mode (development)
+pnpm test:watch
+```
+
+---
+
+## Pull Request Workflow
+
+When you open a PR:
+
+1. ✅ **test** job runs automatically
+2. 📊 Coverage report is posted as a comment
+3. ✅ **lint** and **build** jobs verify code quality
+4. 📝 Summary appears in PR checks
+
+**Example PR comment:**
+```
+## 📊 Test Coverage Report
+
+| Metric | Coverage | Status |
+|--------|----------|--------|
+| Statements | 85.07% | ✅ |
+| Branches | 70.58% | ✅ |
+| Functions | 85% | ✅ |
+| Lines | 88.88% | ✅ |
+```
+
+---
+
+## Troubleshooting
+
+### Tests fail in CI but pass locally
+
+**Possible causes:**
+1. Environment differences (Node version, OS)
+2. Missing environment variables
+3. Flaky tests (timing issues)
+
+**Solutions:**
+- Match Node version locally (20.x)
+- Check CI logs for specific errors
+- Run tests in watch mode to catch flakiness
+
+### Coverage upload fails
+
+**Cause:** Missing or invalid `CODECOV_TOKEN`
+
+**Solution:**
+- Get token from [codecov.io](https://codecov.io)
+- Add as repository secret
+- Or set `fail_ci_if_error: false` (already configured)
+
+### Build fails in CI
+
+**Possible causes:**
+1. TypeScript errors
+2. Missing dependencies
+3. Build configuration issues
+
+**Solutions:**
+```bash
+# Run locally first
+pnpm type-check
+pnpm build
+
+# Check for errors
+pnpm install --frozen-lockfile
+```
+
+---
+
+## Future Enhancements
+
+### Contract Testing (Planned)
+
+Add contract testing workflow:
+
+```yaml
+# .github/workflows/contract-tests.yml
+name: Contract Tests
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours
+  workflow_dispatch:
+
+jobs:
+  contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - run: pnpm install
+      - run: pnpm test:contract
+```
+
+See `.claude/tasks/pending/high_priority/contract-testing-implementation.md` for details.
+
+---
+
+## Workflow Status
+
+| Workflow | Status | Last Run |
+|----------|--------|----------|
+| test.yml | ✅ Active | - |
+| deploy.yml | ✅ Active | - |
+
+---
+
+## Contributing
+
+When adding new workflows:
+
+1. Create workflow in `.github/workflows/`
+2. Test locally with [act](https://github.com/nektos/act) if possible
+3. Document in this README
+4. Add required secrets to repository settings
+5. Test on a feature branch first
+
+---
+
+## Resources
+
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [pnpm Action](https://github.com/pnpm/action-setup)
+- [Codecov Action](https://github.com/codecov/codecov-action)
+- [Vitest Documentation](https://vitest.dev/)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,208 @@
+name: Test Suite
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.1
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run type checking
+        run: pnpm type-check
+
+      - name: Run unit tests
+        run: pnpm test
+
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        if: always()
+        with:
+          file: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Archive coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
+      - name: Comment PR with coverage
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const coveragePath = './coverage/coverage-summary.json';
+
+            if (!fs.existsSync(coveragePath)) {
+              console.log('Coverage summary not found, skipping comment');
+              return;
+            }
+
+            const coverage = JSON.parse(fs.readFileSync(coveragePath, 'utf8'));
+            const total = coverage.total;
+
+            const comment = `## 📊 Test Coverage Report
+
+            | Metric | Coverage | Status |
+            |--------|----------|--------|
+            | **Statements** | ${total.statements.pct}% | ${total.statements.pct >= 60 ? '✅' : '⚠️'} |
+            | **Branches** | ${total.branches.pct}% | ${total.branches.pct >= 50 ? '✅' : '⚠️'} |
+            | **Functions** | ${total.functions.pct}% | ${total.functions.pct >= 60 ? '✅' : '⚠️'} |
+            | **Lines** | ${total.lines.pct}% | ${total.lines.pct >= 60 ? '✅' : '⚠️'} |
+
+            <details>
+            <summary>📝 Coverage Thresholds</summary>
+
+            - Statements: ≥60%
+            - Branches: ≥50%
+            - Functions: ≥60%
+            - Lines: ≥60%
+            </details>
+
+            [View full coverage report in artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+
+      - name: Check coverage thresholds
+        run: |
+          # This step will fail if coverage is below thresholds (configured in vitest.config.ts)
+          echo "Coverage thresholds checked during test:coverage"
+
+  lint:
+    name: Lint Code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for linter
+        id: check_lint
+        run: |
+          if [ -f "package.json" ] && grep -q "\"lint\"" package.json; then
+            echo "has_lint=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_lint=false" >> $GITHUB_OUTPUT
+            echo "⚠️ No lint script found in package.json"
+          fi
+
+      - name: Run linter
+        if: steps.check_lint.outputs.has_lint == 'true'
+        run: pnpm lint
+
+  build:
+    name: Build Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: dist/
+          retention-days: 7
+
+  test-summary:
+    name: Test Summary
+    runs-on: ubuntu-latest
+    needs: [test, lint, build]
+    if: always()
+
+    steps:
+      - name: Check test results
+        run: |
+          echo "## 🎯 Test Suite Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Tests | ${{ needs.test.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Lint | ${{ needs.lint.result == 'success' && '✅ Passed' || needs.lint.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build | ${{ needs.build.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ needs.test.result }}" == "success" ] && [ "${{ needs.build.result }}" == "success" ]; then
+            echo "### ✅ All checks passed!" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          else
+            echo "### ❌ Some checks failed" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ Thumbs.db
 # Auto-generated API types (will be regenerated on build)
 # NOTE: Can be committed if team wants to track schema changes in git
 src/types/api.ts
+
+# Testing
+coverage/
+test-results.xml
+.vitest/
+*.test-results.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,81 @@
 # fire-recovery-frontend
+
+[![Tests](https://github.com/SchmidtDSE/fire-recovery-frontend/actions/workflows/test.yml/badge.svg)](https://github.com/SchmidtDSE/fire-recovery-frontend/actions/workflows/test.yml)
+[![Deploy](https://github.com/SchmidtDSE/fire-recovery-frontend/actions/workflows/deploy.yml/badge.svg)](https://github.com/SchmidtDSE/fire-recovery-frontend/actions/workflows/deploy.yml)
+
 Front end and visualization code for DSE fire recovery project
 
-scriptVegModelURL.js file loads from URL while scriptVegModel.js loads from a locally saved COG file.
+## Development
+
+### Prerequisites
+- Node.js ≥20.0.0
+- pnpm ≥8.0.0
+
+### Setup
+```bash
+pnpm install
+```
+
+### Development Server
+```bash
+pnpm dev
+```
+
+### Testing
+```bash
+# Run tests once
+pnpm test
+
+# Watch mode (re-runs on file changes)
+pnpm test:watch
+
+# Interactive UI
+pnpm test:ui
+
+# With coverage report
+pnpm test:coverage
+```
+
+See [tests/README.md](tests/README.md) for detailed testing guide.
+
+### Type Checking
+```bash
+pnpm type-check
+```
+
+### Build
+```bash
+pnpm build
+```
+
+### API Type Generation
+```bash
+# Generate from dev backend
+pnpm codegen:dev
+
+# Generate from local backend
+pnpm codegen:local
+```
+
+## Project Structure
+
+```
+src/
+├── js/
+│   ├── shared/
+│   │   ├── api/         # API clients (TypeScript)
+│   │   └── utils/       # Utility functions
+│   ├── core/            # State management
+│   └── features/        # Feature modules
+└── types/               # TypeScript definitions
+
+tests/
+├── js/                  # Mirrors src/js/ structure
+├── setup.ts             # Global test setup
+└── test-utils.ts        # Shared test utilities
+```
+
+## Notes
+
+- scriptVegModelURL.js file loads from URL while scriptVegModel.js loads from a locally saved COG file.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "pnpm type-check",
+    "build": "tsc && vite build",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
     "codegen:local": "openapi-typescript http://localhost:8000/openapi.json -o src/types/api.ts",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,23 @@
     "type-check": "tsc --noEmit",
     "codegen:local": "openapi-typescript http://localhost:8000/openapi.json -o src/types/api.ts",
     "codegen:dev": "openapi-typescript https://fire-recovery-backend-dev-113009620257.us-central1.run.app/openapi.json -o src/types/api.ts",
-    "prebuild": "pnpm codegen:dev"
+    "prebuild": "pnpm codegen:dev",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage",
+    "test:ci": "vitest run --coverage --reporter=default --reporter=junit --outputFile=test-results.xml"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",
+    "@vitest/coverage-v8": "^4.0.7",
+    "@vitest/ui": "^4.0.7",
+    "happy-dom": "^20.0.10",
+    "msw": "^2.12.0",
     "openapi-typescript": "^6.7.3",
     "typescript": "^5.3.3",
-    "vite": "^5.0.8"
+    "vite": "^5.0.8",
+    "vitest": "^4.0.7"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ devDependencies:
   '@types/node':
     specifier: ^20.10.0
     version: 20.19.24
+  '@vitest/coverage-v8':
+    specifier: ^4.0.7
+    version: 4.0.7(vitest@4.0.7)
+  '@vitest/ui':
+    specifier: ^4.0.7
+    version: 4.0.7(vitest@4.0.7)
+  happy-dom:
+    specifier: ^20.0.10
+    version: 20.0.10
+  msw:
+    specifier: ^2.12.0
+    version: 2.12.0(@types/node@20.19.24)(typescript@5.9.3)
   openapi-typescript:
     specifier: ^6.7.3
     version: 6.7.6
@@ -17,12 +29,55 @@ devDependencies:
   vite:
     specifier: ^5.0.8
     version: 5.4.21(@types/node@20.19.24)
+  vitest:
+    specifier: ^4.0.7
+    version: 4.0.7(@types/node@20.19.24)(@vitest/ui@4.0.7)(happy-dom@20.0.10)(msw@2.12.0)
 
 packages:
+
+  /@babel/helper-string-parser@7.27.1:
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-identifier@7.28.5:
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/parser@7.28.5:
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.28.5
+    dev: true
+
+  /@babel/types@7.28.5:
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+    dev: true
+
+  /@bcoe/v8-coverage@1.0.2:
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+    dev: true
 
   /@esbuild/aix-ppc64@0.21.5:
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/aix-ppc64@0.25.12:
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
@@ -38,9 +93,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm64@0.25.12:
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm@0.21.5:
     resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.25.12:
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
     requiresBuild: true
@@ -56,9 +129,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-x64@0.25.12:
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-arm64@0.21.5:
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.25.12:
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -74,9 +165,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-x64@0.25.12:
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-arm64@0.21.5:
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.25.12:
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
@@ -92,9 +201,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-x64@0.25.12:
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm64@0.21.5:
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.25.12:
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -110,9 +237,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm@0.25.12:
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ia32@0.21.5:
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.25.12:
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
@@ -128,9 +273,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-loong64@0.25.12:
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-mips64el@0.21.5:
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.25.12:
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
@@ -146,9 +309,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ppc64@0.25.12:
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-riscv64@0.21.5:
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.25.12:
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
@@ -164,11 +345,38 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-s390x@0.25.12:
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-x64@0.21.5:
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.25.12:
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.25.12:
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
     requiresBuild: true
     dev: true
     optional: true
@@ -182,6 +390,24 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.25.12:
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.25.12:
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.21.5:
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
@@ -191,9 +417,36 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.25.12:
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.25.12:
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.21.5:
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.25.12:
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
@@ -209,9 +462,27 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.25.12:
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.21.5:
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.25.12:
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
@@ -227,9 +498,102 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-x64@0.25.12:
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@fastify/busboy@2.1.1:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
+    dev: true
+
+  /@inquirer/ansi@1.0.1:
+    resolution: {integrity: sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@inquirer/confirm@5.1.19(@types/node@20.19.24):
+    resolution: {integrity: sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      '@inquirer/core': 10.3.0(@types/node@20.19.24)
+      '@inquirer/type': 3.0.9(@types/node@20.19.24)
+      '@types/node': 20.19.24
+    dev: true
+
+  /@inquirer/core@10.3.0(@types/node@20.19.24):
+    resolution: {integrity: sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      '@inquirer/ansi': 1.0.1
+      '@inquirer/figures': 1.0.14
+      '@inquirer/type': 3.0.9(@types/node@20.19.24)
+      '@types/node': 20.19.24
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    dev: true
+
+  /@inquirer/figures@1.0.14:
+    resolution: {integrity: sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@inquirer/type@3.0.9(@types/node@20.19.24):
+    resolution: {integrity: sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      '@types/node': 20.19.24
+    dev: true
+
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.5.5:
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.31:
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
+  /@mswjs/interceptors@0.40.0:
+    resolution: {integrity: sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
     dev: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -251,6 +615,25 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+    dev: true
+
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+    dev: true
+
+  /@polka/url@1.0.0-next.29:
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
     dev: true
 
   /@rollup/rollup-android-arm-eabi@4.52.5:
@@ -429,6 +812,21 @@ packages:
     dev: true
     optional: true
 
+  /@standard-schema/spec@1.0.0:
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+    dev: true
+
+  /@types/chai@5.2.3:
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+    dev: true
+
+  /@types/deep-eql@4.0.2:
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+    dev: true
+
   /@types/estree@1.0.8:
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
     dev: true
@@ -439,13 +837,147 @@ packages:
       undici-types: 6.21.0
     dev: true
 
+  /@types/statuses@2.0.6:
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+    dev: true
+
+  /@types/whatwg-mimetype@3.0.2:
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+    dev: true
+
+  /@vitest/coverage-v8@4.0.7(vitest@4.0.7):
+    resolution: {integrity: sha512-MXc+kEA5EUwMMGmNt1S6CIOEl/iCmAhGZQq1QgMNC3/QpYSOxkysEi6pxWhkqJ7YT/RduoVEV5rxFxHG18V3LA==}
+    peerDependencies:
+      '@vitest/browser': 4.0.7
+      vitest: 4.0.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.7
+      ast-v8-to-istanbul: 0.3.8
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.3.5
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.7(@types/node@20.19.24)(@vitest/ui@4.0.7)(happy-dom@20.0.10)(msw@2.12.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitest/expect@4.0.7:
+    resolution: {integrity: sha512-jGRG6HghnJDjljdjYIoVzX17S6uCVCBRFnsgdLGJ6CaxfPh8kzUKe/2n533y4O/aeZ/sIr7q7GbuEbeGDsWv4Q==}
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.7
+      '@vitest/utils': 4.0.7
+      chai: 6.2.0
+      tinyrainbow: 3.0.3
+    dev: true
+
+  /@vitest/mocker@4.0.7(msw@2.12.0)(vite@7.2.0):
+    resolution: {integrity: sha512-OsDwLS7WnpuNslOV6bJkXVYVV/6RSc4eeVxV7h9wxQPNxnjRvTTrIikfwCbMyl8XJmW6oOccBj2Q07YwZtQcCw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 4.0.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      msw: 2.12.0(@types/node@20.19.24)(typescript@5.9.3)
+      vite: 7.2.0(@types/node@20.19.24)
+    dev: true
+
+  /@vitest/pretty-format@4.0.7:
+    resolution: {integrity: sha512-YY//yxqTmk29+/pK+Wi1UB4DUH3lSVgIm+M10rAJ74pOSMgT7rydMSc+vFuq9LjZLhFvVEXir8EcqMke3SVM6Q==}
+    dependencies:
+      tinyrainbow: 3.0.3
+    dev: true
+
+  /@vitest/runner@4.0.7:
+    resolution: {integrity: sha512-orU1lsu4PxLEcDWfjVCNGIedOSF/YtZ+XMrd1PZb90E68khWCNzD8y1dtxtgd0hyBIQk8XggteKN/38VQLvzuw==}
+    dependencies:
+      '@vitest/utils': 4.0.7
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/snapshot@4.0.7:
+    resolution: {integrity: sha512-xJL+Nkw0OjaUXXQf13B8iKK5pI9QVtN9uOtzNHYuG/o/B7fIEg0DQ+xOe0/RcqwDEI15rud1k7y5xznBKGUXAA==}
+    dependencies:
+      '@vitest/pretty-format': 4.0.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+    dev: true
+
+  /@vitest/spy@4.0.7:
+    resolution: {integrity: sha512-FW4X8hzIEn4z+HublB4hBF/FhCVaXfIHm8sUfvlznrcy1MQG7VooBgZPMtVCGZtHi0yl3KESaXTqsKh16d8cFg==}
+    dev: true
+
+  /@vitest/ui@4.0.7(vitest@4.0.7):
+    resolution: {integrity: sha512-aIFPci9xoTmVkxpqsSKcRG/Hn0lTy421jsCehHydYeIMd+getn0Pue0JqY5cW8yZglZjMeX0YfIy5wDtQDHEcA==}
+    peerDependencies:
+      vitest: 4.0.7
+    dependencies:
+      '@vitest/utils': 4.0.7
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vitest: 4.0.7(@types/node@20.19.24)(@vitest/ui@4.0.7)(happy-dom@20.0.10)(msw@2.12.0)
+    dev: true
+
+  /@vitest/utils@4.0.7:
+    resolution: {integrity: sha512-HNrg9CM/Z4ZWB6RuExhuC6FPmLipiShKVMnT9JlQvfhwR47JatWLChA6mtZqVHqypE6p/z6ofcjbyWpM7YLxPQ==}
+    dependencies:
+      '@vitest/pretty-format': 4.0.7
+      tinyrainbow: 3.0.3
+    dev: true
+
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
     dev: true
 
+  /ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: true
+
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: true
+
+  /assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /ast-v8-to-istanbul@0.3.8:
+    resolution: {integrity: sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
     dev: true
 
   /braces@3.0.3:
@@ -453,6 +985,61 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.1.1
+    dev: true
+
+  /chai@6.2.0:
+    resolution: {integrity: sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+    dev: true
+
+  /cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
+  /color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: true
+
+  /color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
+  /emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
+  /es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
     dev: true
 
   /esbuild@0.21.5:
@@ -486,6 +1073,56 @@ packages:
       '@esbuild/win32-x64': 0.21.5
     dev: true
 
+  /esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+    dev: true
+
+  /escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.8
+    dev: true
+
+  /expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
+    dev: true
+
   /fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -503,11 +1140,31 @@ packages:
       reusify: 1.1.0
     dev: true
 
+  /fdir@6.5.0(picomatch@4.0.3):
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.3
+    dev: true
+
+  /fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+    dev: true
+
   /fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
+    dev: true
+
+  /flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
     dev: true
 
   /fsevents@2.3.3:
@@ -518,6 +1175,11 @@ packages:
     dev: true
     optional: true
 
+  /get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dev: true
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -525,9 +1187,41 @@ packages:
       is-glob: 4.0.3
     dev: true
 
+  /graphql@16.12.0:
+    resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
+
+  /happy-dom@20.0.10:
+    resolution: {integrity: sha512-6umCCHcjQrhP5oXhrHQQvLB0bwb1UzHAHdsXy+FjtKoYjUhmNZsQL8NivwM1vDvNEChJabVrUYxUnp/ZdYmy2g==}
+    engines: {node: '>=20.0.0'}
+    dependencies:
+      '@types/node': 20.19.24
+      '@types/whatwg-mimetype': 3.0.2
+      whatwg-mimetype: 3.0.0
+    dev: true
+
+  /has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+    dev: true
+
+  /html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
     dev: true
 
   /is-glob@4.0.3:
@@ -537,9 +1231,50 @@ packages:
       is-extglob: 2.1.1
     dev: true
 
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: true
+
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+    dev: true
+
+  /istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    dev: true
+
+  /js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
     dev: true
 
   /js-yaml@4.1.0:
@@ -547,6 +1282,27 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
+    dev: true
+
+  /magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    dev: true
+
+  /magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      source-map-js: 1.2.1
+    dev: true
+
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.7.3
     dev: true
 
   /merge2@1.4.1:
@@ -560,6 +1316,54 @@ packages:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+    dev: true
+
+  /mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: true
+
+  /msw@2.12.0(@types/node@20.19.24)(typescript@5.9.3):
+    resolution: {integrity: sha512-jzf2eVnd8+iWXN74dccLrHUw3i3hFVvNVQRWS4vBl2KxaUt7Tdur0Eyda/DODGFkZDu2P5MXaeLe/9Qx8PZkrg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@inquirer/confirm': 5.1.19(@types/node@20.19.24)
+      '@mswjs/interceptors': 0.40.0
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.0.2
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.7.0
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      until-async: 3.0.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
+  /mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
     dev: true
 
   /nanoid@3.3.11:
@@ -580,6 +1384,18 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
+  /outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+    dev: true
+
+  /path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+    dev: true
+
+  /pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    dev: true
+
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
     dev: true
@@ -587,6 +1403,11 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: true
+
+  /picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
     dev: true
 
   /postcss@8.5.6:
@@ -600,6 +1421,15 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
+  /require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /rettime@0.7.0:
+    resolution: {integrity: sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==}
     dev: true
 
   /reusify@1.1.0:
@@ -645,9 +1475,73 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
+  /semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+    dev: true
+
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    dev: true
+
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+    dev: true
+
+  /string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
+
+  /strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: true
+
+  /supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
     dev: true
 
   /supports-color@9.4.0:
@@ -655,11 +1549,60 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    dev: true
+
+  /tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    dev: true
+
+  /tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+    dev: true
+
+  /tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tldts-core@7.0.17:
+    resolution: {integrity: sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==}
+    dev: true
+
+  /tldts@7.0.17:
+    resolution: {integrity: sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ==}
+    hasBin: true
+    dependencies:
+      tldts-core: 7.0.17
+    dev: true
+
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+    dev: true
+
+  /totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+    dependencies:
+      tldts: 7.0.17
+    dev: true
+
+  /type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
     dev: true
 
   /typescript@5.9.3:
@@ -677,6 +1620,10 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.1.1
+    dev: true
+
+  /until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
     dev: true
 
   /vite@5.4.21(@types/node@20.19.24):
@@ -718,7 +1665,185 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vite@7.2.0(@types/node@20.19.24):
+    resolution: {integrity: sha512-C/Naxf8H0pBx1PA4BdpT+c/5wdqI9ILMdwjSMILw7tVIh3JsxzZqdeTLmmdaoh5MYUEOyBnM9K3o0DzoZ/fe+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      '@types/node': 20.19.24
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.5
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@4.0.7(@types/node@20.19.24)(@vitest/ui@4.0.7)(happy-dom@20.0.10)(msw@2.12.0):
+    resolution: {integrity: sha512-xQroKAadK503CrmbzCISvQUjeuvEZzv6U0wlnlVFOi5i3gnzfH4onyQ29f3lzpe0FresAiTAd3aqK0Bi/jLI8w==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.7
+      '@vitest/browser-preview': 4.0.7
+      '@vitest/browser-webdriverio': 4.0.7
+      '@vitest/ui': 4.0.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 20.19.24
+      '@vitest/expect': 4.0.7
+      '@vitest/mocker': 4.0.7(msw@2.12.0)(vite@7.2.0)
+      '@vitest/pretty-format': 4.0.7
+      '@vitest/runner': 4.0.7
+      '@vitest/snapshot': 4.0.7
+      '@vitest/spy': 4.0.7
+      '@vitest/ui': 4.0.7(vitest@4.0.7)
+      '@vitest/utils': 4.0.7
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      expect-type: 1.2.2
+      happy-dom: 20.0.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.2.0(@types/node@20.19.24)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
+  /whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
+  /wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
+  /wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
+  /y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
+
+  /yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+    dev: true
+
+  /yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
     dev: true

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,432 @@
+# Testing Guide
+
+## Running Tests
+
+```bash
+# Run all tests once
+pnpm test
+
+# Watch mode (re-run on changes)
+pnpm test:watch
+
+# Web UI (interactive)
+pnpm test:ui
+
+# With coverage report
+pnpm test:coverage
+
+# CI mode (with JUnit output)
+pnpm test:ci
+```
+
+## Test Organization
+
+Tests are organized in a separate `tests/` directory that mirrors the `src/` structure:
+
+```
+tests/
+├── setup.ts              # Global test setup
+├── test-utils.ts         # Shared test utilities
+├── README.md             # This file
+└── js/                   # Mirrors src/js/ structure
+    ├── shared/
+    │   ├── api/
+    │   │   └── api-client.test.ts
+    │   └── utils/
+    │       └── date-utils.test.js
+    └── features/
+        └── fire/
+            └── fire-presenter.test.js
+
+src/
+└── js/                   # Source code
+    ├── shared/
+    │   ├── api/
+    │   │   └── api-client.ts
+    │   └── utils/
+    │       └── date-utils.js
+    └── features/
+        └── fire/
+            └── fire-presenter.js
+```
+
+**Note:** Tests are kept separate from source code in the `tests/` directory. This provides a clean separation between production code and test code.
+
+### Importing Source Files
+
+Since tests are in a separate directory, use the `@` path alias to import source files:
+
+```typescript
+// ✅ Good: Import directly with full file extension
+import { ApiClient } from '@/js/shared/api/api-client.ts'
+import { formatDate } from '@/js/shared/utils/date-utils.js'
+
+// ❌ Avoid: Barrel exports (index.ts) - may have CDN dependencies
+import { ApiClient } from '@/js/shared/api'  // This imports index.ts which has issues
+
+// ❌ Avoid: Relative paths from tests to src
+import { ApiClient } from '../../../../src/js/shared/api/api-client.ts'
+```
+
+**Important:** Always include the full file extension (`.ts` or `.js`) when importing from source files. The `@` alias points to the `src/` directory and is configured in `vitest.config.ts`.
+
+**Note:** TypeScript may show red squiggles on imports in test files, but this is expected - vitest has its own module resolution that works correctly at runtime.
+
+## Writing Tests
+
+### Test Structure
+
+```typescript
+import { describe, it, expect } from 'vitest'
+
+describe('ComponentName', () => {
+  describe('methodName', () => {
+    it('should do something specific', () => {
+      // Arrange
+      const input = 'test'
+
+      // Act
+      const result = someFunction(input)
+
+      // Assert
+      expect(result).toBe('expected')
+    })
+  })
+})
+```
+
+### Mocking HTTP Requests with MSW v2
+
+Use MSW v2 for API mocking with native fetch support:
+
+```typescript
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+// Create mock server
+const server = setupServer()
+
+beforeEach(() => {
+  server.listen({ onUnhandledRequest: 'error' })
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  server.close()
+})
+
+it('should fetch data', async () => {
+  server.use(
+    http.get('http://localhost:8000/api/endpoint', () => {
+      return HttpResponse.json({ data: 'mock' })
+    })
+  )
+
+  // Test code that makes HTTP request
+})
+```
+
+#### MSW v2 Key Features
+
+**GET requests:**
+```typescript
+http.get('http://localhost:8000/api/users/:id', ({ params }) => {
+  return HttpResponse.json({ id: params.id, name: 'Test User' })
+})
+```
+
+**POST requests:**
+```typescript
+http.post('http://localhost:8000/api/users', async ({ request }) => {
+  const body = await request.json()
+  return HttpResponse.json({ id: '123', ...body })
+})
+```
+
+**Error responses:**
+```typescript
+http.get('http://localhost:8000/api/error', () => {
+  return HttpResponse.json(
+    { detail: 'Not found' },
+    { status: 404 }
+  )
+})
+```
+
+**Query parameters:**
+```typescript
+http.get('http://localhost:8000/api/search', ({ request }) => {
+  const url = new URL(request.url)
+  const query = url.searchParams.get('q')
+  return HttpResponse.json({ results: [`Found: ${query}`] })
+})
+```
+
+**Headers:**
+```typescript
+http.get('http://localhost:8000/api/protected', ({ request }) => {
+  const auth = request.headers.get('authorization')
+  if (!auth) {
+    return HttpResponse.json(
+      { detail: 'Unauthorized' },
+      { status: 401 }
+    )
+  }
+  return HttpResponse.json({ data: 'protected' })
+})
+```
+
+### Mocking Functions
+
+```typescript
+import { vi } from 'vitest'
+
+// Create mock function
+const mockFn = vi.fn()
+
+// Set return values
+mockFn.mockReturnValue('mocked')
+mockFn.mockResolvedValue('async mocked')
+
+// Assertions
+expect(mockFn).toHaveBeenCalledWith('arg')
+expect(mockFn).toHaveBeenCalledTimes(1)
+```
+
+### Mocking Modules
+
+```typescript
+import { vi } from 'vitest'
+
+// Mock entire module
+vi.mock('./my-module', () => ({
+  default: {
+    someFunction: vi.fn().mockReturnValue('mocked')
+  }
+}))
+
+// Spy on module function
+import * as myModule from './my-module'
+vi.spyOn(myModule, 'someFunction').mockReturnValue('mocked')
+```
+
+## Test Utilities
+
+See `tests/test-utils.ts` for shared helpers:
+
+- `createMockPolygon()` - Create test GeoJSON polygons
+- `createMockFeature()` - Create test GeoJSON features
+- `createMockApiResponse()` - Create mock fetch responses
+- `waitFor()` - Wait for async operations
+- `flushPromises()` - Flush pending promises
+- `mockApiBaseUrl()` - Mock API base URL
+
+### Example Usage
+
+```typescript
+import { createMockFeature, waitFor } from '../../../tests/test-utils'
+
+it('should process GeoJSON feature', async () => {
+  const feature = createMockFeature({ name: 'Test Fire' })
+  const result = await processFeature(feature)
+
+  await waitFor(100) // Wait for async operations
+
+  expect(result).toBeDefined()
+})
+```
+
+## Coverage Reports
+
+After running `pnpm test:coverage`, open `coverage/index.html` in a browser to view detailed coverage report.
+
+### Coverage Thresholds
+
+Current thresholds (lenient for legacy code):
+- Statements: 60%
+- Branches: 50%
+- Functions: 60%
+- Lines: 60%
+
+New code should aim for higher coverage (90%+).
+
+## CI Integration
+
+In CI pipelines, use:
+
+```bash
+pnpm test:ci
+```
+
+This generates both console output and JUnit XML (`test-results.xml`) for CI systems.
+
+## Testing Best Practices
+
+### 1. Test Pure Functions First
+
+Pure functions (utilities, helpers) are the easiest to test:
+
+```typescript
+// Good - pure function
+export function add(a: number, b: number): number {
+  return a + b
+}
+
+// Test is straightforward
+it('should add two numbers', () => {
+  expect(add(2, 3)).toBe(5)
+})
+```
+
+### 2. Use Descriptive Test Names
+
+```typescript
+// Bad
+it('works', () => { ... })
+
+// Good
+it('should return formatted date in MM/DD/YY format', () => { ... })
+```
+
+### 3. Follow AAA Pattern
+
+```typescript
+it('should calculate area', () => {
+  // Arrange
+  const width = 10
+  const height = 20
+
+  // Act
+  const result = calculateArea(width, height)
+
+  // Assert
+  expect(result).toBe(200)
+})
+```
+
+### 4. Test Edge Cases
+
+```typescript
+describe('divide', () => {
+  it('should divide two numbers', () => {
+    expect(divide(10, 2)).toBe(5)
+  })
+
+  it('should throw error when dividing by zero', () => {
+    expect(() => divide(10, 0)).toThrow('Cannot divide by zero')
+  })
+
+  it('should handle negative numbers', () => {
+    expect(divide(-10, 2)).toBe(-5)
+  })
+})
+```
+
+### 5. Keep Tests Independent
+
+```typescript
+// Bad - tests depend on each other
+let sharedState
+
+it('first test', () => {
+  sharedState = 'modified'
+})
+
+it('second test', () => {
+  expect(sharedState).toBe('modified') // Brittle!
+})
+
+// Good - each test is independent
+it('first test', () => {
+  const state = 'initial'
+  // Test with local state
+})
+
+it('second test', () => {
+  const state = 'initial'
+  // Test with fresh state
+})
+```
+
+### 6. Mock External Dependencies
+
+```typescript
+// Mock API calls
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+const server = setupServer()
+
+beforeEach(() => server.listen())
+afterEach(() => server.close())
+
+it('should fetch user data', async () => {
+  server.use(
+    http.get('http://localhost:8000/api/users/1', () => {
+      return HttpResponse.json({ id: 1, name: 'Test' })
+    })
+  )
+
+  const user = await fetchUser(1)
+  expect(user.name).toBe('Test')
+})
+```
+
+## Troubleshooting
+
+### Tests Not Running
+
+1. Check that test files match the pattern: `*.test.{js,ts}` or `*.spec.{js,ts}`
+2. Verify files are not in excluded directories (node_modules, dist, etc.)
+3. Run `pnpm test --reporter=verbose` for detailed output
+
+### Import Errors
+
+1. Verify path aliases are configured correctly in `vitest.config.ts`
+2. Check that `@/` resolves to `./src`
+3. Use relative paths if absolute paths fail
+
+### MSW Not Working
+
+1. Ensure you're using MSW v2 syntax (`http` and `HttpResponse` from 'msw')
+2. Check that handlers are registered before tests run
+3. Verify base URLs match exactly in handlers
+4. Use `onUnhandledRequest: 'error'` to catch missing handlers
+
+### Coverage Issues
+
+1. Check coverage exclusions in `vitest.config.ts`
+2. Verify test files are excluded from coverage
+3. Run `pnpm test:coverage -- --reporter=verbose` for detailed info
+
+## Known Limitations
+
+### CDN Dependencies
+
+Some files cannot be tested yet due to CDN imports:
+- `src/js/core/state-manager.js` - imports d3-dispatch from CDN
+- Files that import state-manager
+
+**Workaround:** Mock these modules in tests or wait for CDN to pnpm migration.
+
+### Browser APIs
+
+Some browser APIs may not be available in tests:
+- `FileReader`, `Blob`, etc. are available via happy-dom
+- Complex APIs may need manual mocking in `tests/setup.ts`
+
+## Next Steps
+
+After setup:
+
+1. Write tests for new code as it's developed
+2. Add tests for existing code during refactoring
+3. Increase coverage thresholds gradually
+4. Consider integration tests with Playwright
+5. Add visual regression tests if needed
+
+## References
+
+- [Vitest Documentation](https://vitest.dev/)
+- [MSW v2 Documentation](https://mswjs.io/)
+- [happy-dom Documentation](https://github.com/capricorn86/happy-dom)

--- a/tests/js/shared/api/api-client.test.ts
+++ b/tests/js/shared/api/api-client.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Tests for API Client
+ * Uses MSW v2 for HTTP mocking with native fetch support
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { ApiClient, ApiError, apiClient } from '@/js/shared/api/api-client.ts'
+
+// Create mock server
+const server = setupServer()
+
+beforeEach(() => {
+  server.listen({ onUnhandledRequest: 'error' })
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  server.close()
+})
+
+describe('ApiClient', () => {
+  describe('constructor', () => {
+    it('should use provided base URL', () => {
+      const client = new ApiClient('http://test.example.com/api')
+      expect(client.getBaseUrl()).toBe('http://test.example.com/api')
+    })
+
+    it('should use default base URL from config when not provided', () => {
+      const client = new ApiClient()
+      expect(client.getBaseUrl()).toContain('fire-recovery')
+    })
+
+    it('should use singleton instance correctly', () => {
+      expect(apiClient).toBeInstanceOf(ApiClient)
+      expect(apiClient.getBaseUrl()).toContain('fire-recovery')
+    })
+  })
+
+  describe('get', () => {
+    it('should make successful GET request', async () => {
+      const mockData = { status: 'success', data: 'test' }
+
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json(mockData)
+        })
+      )
+
+      const result = await apiClient.get('/fire-recovery/test' as any)
+      expect(result).toEqual(mockData)
+    })
+
+    it('should include query parameters', async () => {
+      let capturedParams: URLSearchParams | null = null
+
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', ({ request }) => {
+          const url = new URL(request.url)
+          capturedParams = url.searchParams
+          return HttpResponse.json({ ok: true })
+        })
+      )
+
+      await apiClient.get('/fire-recovery/test' as any, {
+        params: { foo: 'bar', baz: 123, flag: true }
+      })
+
+      expect(capturedParams?.get('foo')).toBe('bar')
+      expect(capturedParams?.get('baz')).toBe('123')
+      expect(capturedParams?.get('flag')).toBe('true')
+    })
+
+    it('should include custom headers', async () => {
+      let capturedHeaders: Headers | null = null
+
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', ({ request }) => {
+          capturedHeaders = request.headers
+          return HttpResponse.json({ ok: true })
+        })
+      )
+
+      await apiClient.get('/fire-recovery/test' as any, {
+        headers: { 'X-Custom-Header': 'test-value' }
+      })
+
+      expect(capturedHeaders?.get('X-Custom-Header')).toBe('test-value')
+    })
+
+    it('should include Accept header by default', async () => {
+      let capturedHeaders: Headers | null = null
+
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', ({ request }) => {
+          capturedHeaders = request.headers
+          return HttpResponse.json({ ok: true })
+        })
+      )
+
+      await apiClient.get('/fire-recovery/test' as any)
+
+      expect(capturedHeaders?.get('Accept')).toBe('application/json')
+    })
+
+    it('should throw ApiError on 404', async () => {
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json(
+            { detail: 'Not found' },
+            { status: 404 }
+          )
+        })
+      )
+
+      await expect(
+        apiClient.get('/fire-recovery/test' as any)
+      ).rejects.toThrow(ApiError)
+    })
+
+    it('should throw ApiError with correct status and message', async () => {
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json(
+            { detail: 'Bad request', message: 'Invalid parameters' },
+            { status: 400 }
+          )
+        })
+      )
+
+      try {
+        await apiClient.get('/fire-recovery/test' as any)
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).status).toBe(400)
+        expect((error as ApiError).message).toContain('Bad request')
+        expect((error as ApiError).details).toEqual({
+          detail: 'Bad request',
+          message: 'Invalid parameters'
+        })
+      }
+    })
+
+    it('should handle validation errors (422)', async () => {
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json(
+            {
+              detail: [
+                { msg: 'Field required', loc: ['body', 'fire_event_name'] },
+                { msg: 'Invalid date', loc: ['body', 'start_date'] }
+              ]
+            },
+            { status: 422 }
+          )
+        })
+      )
+
+      try {
+        await apiClient.get('/fire-recovery/test' as any)
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).status).toBe(422)
+        expect((error as ApiError).message).toContain('Field required')
+        expect((error as ApiError).message).toContain('body.fire_event_name')
+      }
+    })
+
+    it('should handle server errors (500)', async () => {
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json(
+            { detail: 'Internal server error' },
+            { status: 500 }
+          )
+        })
+      )
+
+      try {
+        await apiClient.get('/fire-recovery/test' as any)
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).status).toBe(500)
+      }
+    })
+
+    it('should handle malformed error responses', async () => {
+      server.use(
+        http.get('http://localhost:8000/fire-recovery/test', () => {
+          return new HttpResponse(null, { status: 500 })
+        })
+      )
+
+      try {
+        await apiClient.get('/fire-recovery/test' as any)
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).status).toBe(500)
+      }
+    })
+  })
+
+  describe('post', () => {
+    it('should make successful POST request with body', async () => {
+      const requestBody = { fire_event_name: 'Test Fire', coordinates: [[0, 0]] }
+      const responseData = { job_id: '123', status: 'pending' }
+
+      let capturedBody: any = null
+
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/test', async ({ request }) => {
+          capturedBody = await request.json()
+          return HttpResponse.json(responseData)
+        })
+      )
+
+      const result = await apiClient.post('/fire-recovery/test' as any, {
+        body: requestBody
+      })
+
+      expect(result).toEqual(responseData)
+      expect(capturedBody).toEqual(requestBody)
+    })
+
+    it('should include Content-Type header', async () => {
+      let capturedHeaders: Headers | null = null
+
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/test', ({ request }) => {
+          capturedHeaders = request.headers
+          return HttpResponse.json({ ok: true })
+        })
+      )
+
+      await apiClient.post('/fire-recovery/test' as any, {
+        body: { test: 'data' }
+      })
+
+      expect(capturedHeaders?.get('Content-Type')).toBe('application/json')
+      expect(capturedHeaders?.get('Accept')).toBe('application/json')
+    })
+
+    it('should handle POST without body', async () => {
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json({ ok: true })
+        })
+      )
+
+      const result = await apiClient.post('/fire-recovery/test' as any)
+      expect(result).toEqual({ ok: true })
+    })
+
+    it('should include custom headers', async () => {
+      let capturedHeaders: Headers | null = null
+
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/test', ({ request }) => {
+          capturedHeaders = request.headers
+          return HttpResponse.json({ ok: true })
+        })
+      )
+
+      await apiClient.post('/fire-recovery/test' as any, {
+        body: {},
+        headers: { 'X-Request-ID': 'abc123' }
+      })
+
+      expect(capturedHeaders?.get('X-Request-ID')).toBe('abc123')
+    })
+
+    it('should throw ApiError on validation error', async () => {
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json(
+            {
+              detail: [
+                { msg: 'Field required', loc: ['body', 'fire_event_name'] }
+              ]
+            },
+            { status: 422 }
+          )
+        })
+      )
+
+      await expect(
+        apiClient.post('/fire-recovery/test' as any, { body: {} })
+      ).rejects.toThrow('Field required')
+    })
+
+    it('should throw ApiError on conflict (409)', async () => {
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json(
+            { detail: 'Resource already exists' },
+            { status: 409 }
+          )
+        })
+      )
+
+      try {
+        await apiClient.post('/fire-recovery/test' as any, { body: {} })
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).status).toBe(409)
+        expect((error as ApiError).message).toContain('Resource already exists')
+      }
+    })
+
+    it('should handle empty response body', async () => {
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/test', () => {
+          return HttpResponse.json({})
+        })
+      )
+
+      const result = await apiClient.post('/fire-recovery/test' as any, {
+        body: { test: 'data' }
+      })
+      expect(result).toEqual({})
+    })
+  })
+
+  describe('upload', () => {
+    it('should upload FormData successfully', async () => {
+      const mockResponse = { url: 'https://example.com/file.zip' }
+      let capturedContentType: string | null = null
+
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/upload', ({ request }) => {
+          capturedContentType = request.headers.get('content-type')
+          return HttpResponse.json(mockResponse)
+        })
+      )
+
+      const formData = new FormData()
+      formData.append('file', new Blob(['test content'], { type: 'text/plain' }), 'test.txt')
+      formData.append('name', 'test-upload')
+
+      const result = await apiClient.upload('/fire-recovery/upload', formData)
+      expect(result).toEqual(mockResponse)
+      expect(capturedContentType).toContain('multipart/form-data')
+    })
+
+    it('should handle multiple files in FormData', async () => {
+      const mockResponse = { files: ['file1.txt', 'file2.txt'] }
+
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/upload', () => {
+          return HttpResponse.json(mockResponse)
+        })
+      )
+
+      const formData = new FormData()
+      formData.append('file1', new Blob(['content1']), 'file1.txt')
+      formData.append('file2', new Blob(['content2']), 'file2.txt')
+
+      const result = await apiClient.upload('/fire-recovery/upload', formData)
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should throw ApiError on upload failure', async () => {
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/upload', () => {
+          return HttpResponse.json(
+            { detail: 'File too large' },
+            { status: 413 }
+          )
+        })
+      )
+
+      const formData = new FormData()
+      formData.append('file', new Blob(['x'.repeat(1000000)]), 'large.txt')
+
+      await expect(
+        apiClient.upload('/fire-recovery/upload', formData)
+      ).rejects.toThrow('File too large')
+    })
+
+    it('should throw ApiError on unsupported file type', async () => {
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/upload', () => {
+          return HttpResponse.json(
+            { detail: 'Unsupported file type' },
+            { status: 415 }
+          )
+        })
+      )
+
+      const formData = new FormData()
+      formData.append('file', new Blob(['test']), 'test.exe')
+
+      try {
+        await apiClient.upload('/fire-recovery/upload', formData)
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError)
+        expect((error as ApiError).status).toBe(415)
+      }
+    })
+
+    it('should handle empty FormData', async () => {
+      const mockResponse = { message: 'No files uploaded' }
+
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/upload', () => {
+          return HttpResponse.json(mockResponse)
+        })
+      )
+
+      const formData = new FormData()
+      const result = await apiClient.upload('/fire-recovery/upload', formData)
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should not include Content-Type header (let browser set it)', async () => {
+      let capturedHeaders: Headers | null = null
+
+      server.use(
+        http.post('http://localhost:8000/fire-recovery/upload', ({ request }) => {
+          capturedHeaders = request.headers
+          return HttpResponse.json({ ok: true })
+        })
+      )
+
+      const formData = new FormData()
+      formData.append('file', new Blob(['test']), 'test.txt')
+      await apiClient.upload('/fire-recovery/upload', formData)
+
+      // Browser sets Content-Type with boundary for multipart/form-data
+      // We should not manually set it
+      expect(capturedHeaders?.get('content-type')).toContain('multipart/form-data')
+    })
+  })
+
+  describe('getBaseUrl', () => {
+    it('should return the configured base URL', () => {
+      const client = new ApiClient('http://test.example.com')
+      expect(client.getBaseUrl()).toBe('http://test.example.com')
+    })
+  })
+})
+
+describe('ApiError', () => {
+  it('should create error with status and message', () => {
+    const error = new ApiError(404, 'Not found')
+    expect(error.status).toBe(404)
+    expect(error.message).toBe('Not found')
+    expect(error.name).toBe('ApiError')
+  })
+
+  it('should include details when provided', () => {
+    const details = { detail: 'Validation failed', field: 'email' }
+    const error = new ApiError(400, 'Bad request', details)
+    expect(error.details).toEqual(details)
+  })
+
+  it('should be an instance of Error', () => {
+    const error = new ApiError(500, 'Server error')
+    expect(error).toBeInstanceOf(Error)
+  })
+
+  it('should have correct error name', () => {
+    const error = new ApiError(403, 'Forbidden')
+    expect(error.name).toBe('ApiError')
+  })
+
+  it('should handle missing details', () => {
+    const error = new ApiError(401, 'Unauthorized')
+    expect(error.details).toBeUndefined()
+  })
+
+  it('should be throwable and caught in try-catch', () => {
+    expect(() => {
+      throw new ApiError(500, 'Test error')
+    }).toThrow(ApiError)
+  })
+})

--- a/tests/js/shared/utils/date-utils.test.js
+++ b/tests/js/shared/utils/date-utils.test.js
@@ -1,0 +1,301 @@
+/**
+ * Tests for Date Utilities
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  formatDate,
+  getTodayISO,
+  getRelativeDateISO,
+  isDateInRange,
+  getDaysBetweenDates,
+  createFireDateRange
+} from '@/js/shared/utils/date-utils.js'
+
+describe('date-utils', () => {
+  describe('formatDate', () => {
+    it('should format ISO date to MM/DD/YY by default', () => {
+      const result = formatDate('2024-03-15')
+      expect(result).toBe('03/15/24')
+    })
+
+    it('should format ISO date at start of year', () => {
+      const result = formatDate('2024-01-01')
+      expect(result).toBe('01/01/24')
+    })
+
+    it('should format ISO date at end of year', () => {
+      const result = formatDate('2024-12-31')
+      expect(result).toBe('12/31/24')
+    })
+
+    it('should handle custom formatting options', () => {
+      const result = formatDate('2024-03-15', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      })
+      // Note: toLocaleDateString may vary by system locale
+      expect(result).toContain('March')
+      expect(result).toContain('15')
+      expect(result).toContain('2024')
+    })
+
+    it('should handle partial custom options', () => {
+      const result = formatDate('2024-03-15', {
+        month: 'long',
+        year: 'numeric'
+      })
+      expect(result).toContain('March')
+      expect(result).toContain('2024')
+    })
+
+    it('should handle different years', () => {
+      expect(formatDate('2023-06-15')).toBe('06/15/23')
+      expect(formatDate('2025-09-30')).toBe('09/30/25')
+    })
+  })
+
+  describe('getTodayISO', () => {
+    it('should return date in YYYY-MM-DD format', () => {
+      const result = getTodayISO()
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+
+    it('should return a valid ISO date string', () => {
+      const result = getTodayISO()
+      const date = new Date(result)
+      expect(date).toBeInstanceOf(Date)
+      expect(isNaN(date.getTime())).toBe(false)
+    })
+
+    it('should return current date', () => {
+      const result = getTodayISO()
+      const today = new Date().toISOString().split('T')[0]
+      expect(result).toBe(today)
+    })
+  })
+
+  describe('getRelativeDateISO', () => {
+    it('should return date 7 days in the past', () => {
+      const result = getRelativeDateISO(-7)
+      const expected = new Date()
+      expected.setDate(expected.getDate() - 7)
+      expect(result).toBe(expected.toISOString().split('T')[0])
+    })
+
+    it('should return date 7 days in the future', () => {
+      const result = getRelativeDateISO(7)
+      const expected = new Date()
+      expected.setDate(expected.getDate() + 7)
+      expect(result).toBe(expected.toISOString().split('T')[0])
+    })
+
+    it('should return today when passed 0', () => {
+      const result = getRelativeDateISO(0)
+      const today = new Date().toISOString().split('T')[0]
+      expect(result).toBe(today)
+    })
+
+    it('should handle large negative offsets', () => {
+      const result = getRelativeDateISO(-365)
+      const expected = new Date()
+      expected.setDate(expected.getDate() - 365)
+      expect(result).toBe(expected.toISOString().split('T')[0])
+    })
+
+    it('should handle large positive offsets', () => {
+      const result = getRelativeDateISO(365)
+      const expected = new Date()
+      expected.setDate(expected.getDate() + 365)
+      expect(result).toBe(expected.toISOString().split('T')[0])
+    })
+
+    it('should return valid ISO format', () => {
+      const result = getRelativeDateISO(-30)
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+  })
+
+  describe('isDateInRange', () => {
+    it('should return true for date within range', () => {
+      const result = isDateInRange('2024-03-15', '2024-03-01', '2024-03-31')
+      expect(result).toBe(true)
+    })
+
+    it('should return false for date before range', () => {
+      const result = isDateInRange('2024-02-28', '2024-03-01', '2024-03-31')
+      expect(result).toBe(false)
+    })
+
+    it('should return false for date after range', () => {
+      const result = isDateInRange('2024-04-01', '2024-03-01', '2024-03-31')
+      expect(result).toBe(false)
+    })
+
+    it('should include start boundary date', () => {
+      const result = isDateInRange('2024-03-01', '2024-03-01', '2024-03-31')
+      expect(result).toBe(true)
+    })
+
+    it('should include end boundary date', () => {
+      const result = isDateInRange('2024-03-31', '2024-03-01', '2024-03-31')
+      expect(result).toBe(true)
+    })
+
+    it('should handle single day range', () => {
+      const result = isDateInRange('2024-03-15', '2024-03-15', '2024-03-15')
+      expect(result).toBe(true)
+    })
+
+    it('should handle year boundaries', () => {
+      expect(isDateInRange('2024-01-01', '2023-12-01', '2024-01-31')).toBe(true)
+      expect(isDateInRange('2023-12-31', '2023-12-01', '2024-01-31')).toBe(true)
+    })
+
+    it('should return false when date is just outside start', () => {
+      const result = isDateInRange('2024-02-29', '2024-03-01', '2024-03-31')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getDaysBetweenDates', () => {
+    it('should calculate days between two dates', () => {
+      const result = getDaysBetweenDates('2024-03-01', '2024-03-15')
+      expect(result).toBe(14)
+    })
+
+    it('should return 0 for same date', () => {
+      const result = getDaysBetweenDates('2024-03-15', '2024-03-15')
+      expect(result).toBe(0)
+    })
+
+    it('should return negative for reversed dates', () => {
+      const result = getDaysBetweenDates('2024-03-15', '2024-03-01')
+      expect(result).toBe(-14)
+    })
+
+    it('should handle one day difference', () => {
+      const result = getDaysBetweenDates('2024-03-15', '2024-03-16')
+      expect(result).toBe(1)
+    })
+
+    it('should handle month boundaries', () => {
+      const result = getDaysBetweenDates('2024-03-30', '2024-04-02')
+      expect(result).toBe(3)
+    })
+
+    it('should handle year boundaries', () => {
+      const result = getDaysBetweenDates('2023-12-30', '2024-01-02')
+      expect(result).toBe(3)
+    })
+
+    it('should handle leap year', () => {
+      const result = getDaysBetweenDates('2024-02-28', '2024-03-01')
+      expect(result).toBe(2) // 2024 is a leap year
+    })
+
+    it('should handle non-leap year', () => {
+      const result = getDaysBetweenDates('2023-02-28', '2023-03-01')
+      expect(result).toBe(1) // 2023 is not a leap year
+    })
+
+    it('should handle large date ranges', () => {
+      const result = getDaysBetweenDates('2024-01-01', '2024-12-31')
+      expect(result).toBe(365) // 2024 is a leap year
+    })
+  })
+
+  describe('createFireDateRange', () => {
+    it('should create date range with default values', () => {
+      const result = createFireDateRange()
+
+      expect(result).toHaveProperty('prefireStart')
+      expect(result).toHaveProperty('prefireEnd')
+      expect(result).toHaveProperty('postfireStart')
+      expect(result).toHaveProperty('postfireEnd')
+
+      // All should be ISO date strings
+      expect(result.prefireStart).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(result.prefireEnd).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(result.postfireStart).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(result.postfireEnd).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+
+    it('should create dates in correct chronological order', () => {
+      const result = createFireDateRange()
+
+      const preStart = new Date(result.prefireStart)
+      const preEnd = new Date(result.prefireEnd)
+      const postStart = new Date(result.postfireStart)
+      const postEnd = new Date(result.postfireEnd)
+
+      // Verify the relative ordering (all dates should be in the past with defaults)
+      expect(preStart < preEnd).toBe(true)
+      expect(preEnd < postStart).toBe(true)
+      expect(postStart < postEnd).toBe(true)
+    })
+
+    it('should create date range with custom values', () => {
+      const result = createFireDateRange(100, 80, 40, 20)
+
+      const preStart = new Date(result.prefireStart)
+      const preEnd = new Date(result.prefireEnd)
+      const postStart = new Date(result.postfireStart)
+      const postEnd = new Date(result.postfireEnd)
+
+      // Verify the relative ordering
+      expect(preStart < preEnd).toBe(true)
+      expect(preEnd < postStart).toBe(true)
+      expect(postStart < postEnd).toBe(true)
+    })
+
+    it('should use default values (60, 45, 30, 15) when called without arguments', () => {
+      const result = createFireDateRange()
+      const today = new Date()
+
+      const preStart = new Date(result.prefireStart)
+      const preEnd = new Date(result.prefireEnd)
+      const postStart = new Date(result.postfireStart)
+      const postEnd = new Date(result.postfireEnd)
+
+      // Calculate expected dates
+      const expectedPreStart = new Date(today)
+      expectedPreStart.setDate(today.getDate() - 60)
+      const expectedPreEnd = new Date(today)
+      expectedPreEnd.setDate(today.getDate() - 45)
+      const expectedPostStart = new Date(today)
+      expectedPostStart.setDate(today.getDate() - 30)
+      const expectedPostEnd = new Date(today)
+      expectedPostEnd.setDate(today.getDate() - 15)
+
+      // Verify dates match expected (within same day)
+      expect(preStart.toISOString().split('T')[0]).toBe(expectedPreStart.toISOString().split('T')[0])
+      expect(preEnd.toISOString().split('T')[0]).toBe(expectedPreEnd.toISOString().split('T')[0])
+      expect(postStart.toISOString().split('T')[0]).toBe(expectedPostStart.toISOString().split('T')[0])
+      expect(postEnd.toISOString().split('T')[0]).toBe(expectedPostEnd.toISOString().split('T')[0])
+    })
+
+    it('should handle custom values with different spacing', () => {
+      const result = createFireDateRange(10, 8, 4, 2)
+
+      const preStart = new Date(result.prefireStart)
+      const preEnd = new Date(result.prefireEnd)
+      const postStart = new Date(result.postfireStart)
+      const postEnd = new Date(result.postfireEnd)
+
+      // Calculate expected day differences
+      const preFireDays = Math.abs(getDaysBetweenDates(result.prefireStart, result.prefireEnd))
+      const postFireDays = Math.abs(getDaysBetweenDates(result.postfireStart, result.postfireEnd))
+
+      expect(preFireDays).toBe(2)  // 10 - 8
+      expect(postFireDays).toBe(2) // 4 - 2
+    })
+
+    it('should handle zero values', () => {
+      const result = createFireDateRange(5, 4, 2, 0)
+
+      expect(result.postfireEnd).toBe(getTodayISO())
+    })
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,35 @@
+/**
+ * Global test setup
+ * Runs once before all test files
+ */
+
+import { vi, beforeAll } from 'vitest'
+
+// Mock browser APIs that might not exist in test environment
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}))
+
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}))
+
+// Mock shp.js library for shapefile parsing tests
+// @ts-ignore
+global.shp = vi.fn().mockResolvedValue({
+  type: 'FeatureCollection',
+  features: []
+})
+
+// Mock environment variables for tests
+process.env.VITE_API_BASE_URL = 'http://localhost:8000'
+
+// Optional: Suppress console logs during tests (uncomment if needed)
+// beforeAll(() => {
+//   vi.spyOn(console, 'log').mockImplementation(() => {})
+//   vi.spyOn(console, 'warn').mockImplementation(() => {})
+// })

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared test utilities and helpers
+ */
+
+/**
+ * Create a mock GeoJSON Polygon for testing
+ */
+export function createMockPolygon(coordinates?: number[][][]) {
+  return {
+    type: 'Polygon' as const,
+    coordinates: coordinates || [
+      [
+        [-117.1, 33.9],
+        [-117.0, 33.9],
+        [-117.0, 34.0],
+        [-117.1, 34.0],
+        [-117.1, 33.9]
+      ]
+    ]
+  }
+}
+
+/**
+ * Create a mock GeoJSON Feature for testing
+ */
+export function createMockFeature(properties = {}) {
+  return {
+    type: 'Feature' as const,
+    geometry: createMockPolygon(),
+    properties
+  }
+}
+
+/**
+ * Create a mock API response for testing
+ */
+export function createMockApiResponse<T>(data: T, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  } as Response
+}
+
+/**
+ * Wait for async operations to complete
+ */
+export function waitFor(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Flush all pending promises
+ */
+export async function flushPromises() {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+/**
+ * Mock the API base URL for tests
+ */
+export function mockApiBaseUrl(url: string = 'http://localhost:8000') {
+  const originalEnv = import.meta.env.VITE_API_BASE_URL
+
+  // @ts-ignore
+  import.meta.env.VITE_API_BASE_URL = url
+
+  return () => {
+    // @ts-ignore
+    import.meta.env.VITE_API_BASE_URL = originalEnv
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,5 +35,12 @@
     "src/**/*.tsx",
     "src/types/**/*"
   ],
-  "exclude": ["node_modules", "dist", "src/**/*.js"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.js",
+    "src/**/*.test.ts",
+    "src/**/*.test.js",
+    "tests/**/*"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    // Test environment
+    environment: 'happy-dom',
+
+    // Environment matching (optimization)
+    environmentMatchGlobs: [
+      // Pure utility tests run in Node (faster)
+      ['tests/**/date-utils.test.js', 'node'],
+      ['tests/**/geojson-utils.test.js', 'node'],
+      // API tests run in Node (no DOM needed)
+      ['tests/**/api/*.test.ts', 'node'],
+    ],
+
+    // Test file patterns (tests live in separate tests/ directory)
+    include: [
+      'tests/**/*.{test,spec}.{js,ts}'
+    ],
+    exclude: [
+      'node_modules',
+      'dist',
+      '.claude',
+      'src/tmp'
+    ],
+
+    // Global test utilities
+    globals: true,
+
+    // Coverage configuration
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov', 'json'],
+      reportsDirectory: './coverage',
+      exclude: [
+        'node_modules/',
+        'tests/',
+        '**/*.d.ts',
+        '**/*.config.{js,ts}',
+        '**/*.test.{js,ts}',
+        '**/*.spec.{js,ts}',
+        'dist/',
+        'src/types/api.ts',
+        'src/tmp/',
+      ],
+      statements: 60,
+      branches: 50,
+      functions: 60,
+      lines: 60,
+    },
+
+    // Timeout for async tests
+    testTimeout: 10000,
+
+    // Watch mode configuration
+    watch: false,
+
+    // Reporter configuration
+    reporters: ['default'],
+
+    // Setup files
+    setupFiles: ['./tests/setup.ts'],
+
+    // Mock reset behavior
+    mockReset: true,
+    restoreMocks: true,
+  },
+
+  // Path aliases (must match tsconfig.json and vite.config.ts)
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})


### PR DESCRIPTION
---
  Add unit testing framework and sets up Vitest 
  
  Tests live in tests/ directory that mirrors src/ structure (not co-located with
  source files). Import from source using @/ path alias with full file extensions:

```  
  import { ApiClient } from '@/js/shared/api/api-client.ts'
```

  Commands:

  - pnpm test - run tests once
  - pnpm test:watch - watch mode
  - pnpm test:coverage - generate coverage report
